### PR TITLE
Fix Korean subtitle enabled issue for Loom (CD)

### DIFF
--- a/engines/scumm/string.cpp
+++ b/engines/scumm/string.cpp
@@ -793,6 +793,10 @@ void ScummEngine::CHARSET_1() {
 					// Special case for HE games
 				} else if (_game.id == GID_LOOM && !ConfMan.getBool("subtitles") && (_sound->pollCD())) {
 					// Special case for Loom (CD), since it only uses CD audio.for sound
+#ifdef SCUMMVMKOR
+					if(_koreanOnly) // LOOM CD 버전에서 한글자막 자동활성화 안되는 문제 수정
+						_c1KorBuffer = addKoreanBuffer(_c1KorBuffer, c);
+#endif
 				} else if (!ConfMan.getBool("subtitles") && (!_haveActorSpeechMsg || _mixer->isSoundHandleActive(*_sound->_talkChannelHandle))) {
 					// Subtitles are turned off, and there is a voice version
 					// of this message -> don't print it.


### PR DESCRIPTION
Loom (CD) 버전일 경우 게임 옵션에 한글자막이 켜져있음에도 게임내 자막이 자동활성화되지 않던 문제 수정